### PR TITLE
Change UIRoot_Entry patch target. Should fix patching errors for some users

### DIFF
--- a/Source/Classes/RealRuins.cs
+++ b/Source/Classes/RealRuins.cs
@@ -53,7 +53,7 @@ namespace RealRuins
         }
 
         
-        [HarmonyPatch(typeof(UIRoot_Entry), "Init", new Type[0])]
+        [HarmonyPatch(typeof(UIRoot_Entry), nameof(UIRoot_Entry.Init))]
         static class UIRoot_Entry_Init_Patch {
             static void Postfix() {
                 if (RealRuins_ModSettings.allowDownloads && !RealRuins_ModSettings.offlineMode && SnapshotStoreManager.Instance.StoredSnapshotsCount() < 100) {


### PR DESCRIPTION
Some users have issues with the UIRoot_Entry patch applying. This should fix the problem.

https://gist.github.com/search?utf8=%E2%9C%93&q=user%3AHugsLibRecordKeeper+%22No+target+method+specified+for+class+RealRuins.RealRuins%2BUIRoot_Entry_Init_Patch%22&ref=searchresults